### PR TITLE
Swapped Strings for Errors; Forge Tests Cases for Discretionary Relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,24 @@ To Sepolia
 ```bash
 npx hardhat ignition deploy ./ignition/modules/Lock.ts --network sepolia
 ```
+
+# Testing
+
+## Setup
+
+Install Foundry
+
+```bash
+# Download foundry installer `foundryup`
+curl -L https://foundry.paradigm.xyz | bash
+# Install forge, cast, anvil, chisel
+foundryup
+```
+
+## Run Tests
+
+Run the Foundry unit tests using the following command:
+
+```bash
+forge test
+```

--- a/README.md
+++ b/README.md
@@ -49,3 +49,24 @@ Run the Foundry unit tests using the following command:
 ```bash
 forge test
 ```
+
+### Run Single Test
+To run a single test, you can use the `--match-test` option with the function name. For example:
+
+```bash
+forge test --match-test testCreateRelayHappyPath
+```
+
+### Debugging Tests
+To debug a test, you can use the `console.log`. This will allow you to print variables and other information during the test execution.
+
+```solidity
+// Import the console library from Forge
+import {console} from "../../lib/forge-std/src/console.sol";
+// In your test function, you can use console.log to print variables
+console.log(block.timestamp);
+```
+To see the console logs, you need to run the test with the `-vvvv` flag:
+```bash
+forge test -vvvv
+```

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,2 @@
+[profile.default]
+via_ir = true

--- a/lib/DiscretionaryRelay.sol
+++ b/lib/DiscretionaryRelay.sol
@@ -10,12 +10,11 @@ contract DiscretionaryRelay is UndisputableRelayBase {
 
     function returnRelay(address _creator, uint _index) external override {
         EscrowStructs.Relay storage relay = relays[_creator][_index];
-        require(relay.isLocked == true, "TransactionRelay: can only return funds if locked");
-        require(relay.isApproved == false, "TransactionRelay: can not return funds if already approved");
-        require(relay.isReturning == false, "TransactionRelay: can not return funds if already returning");
-        require(relay.allowReturnAfter < block.timestamp, "TransactionRelay: can not return funds before allowReturnAfter");
+        require(relay.isLocked == true, ErrRelayNotLocked());
+        require(!relay.isApproved && !relay.isReturning, ErrRelayAlreadyApprovedOrReturned());
+        require(relay.allowReturnAfter < block.timestamp, ErrNotAfterAllowReturnTimestamp());
 
-        require(relay.payer == msg.sender, "TransactionRelay: only the payer can return funds (if conditional)");
+        require(relay.payer == msg.sender, ErrSenderNotPayer());
 
         relays[_creator][_index].isReturning = true;
 

--- a/lib/IRelay.sol
+++ b/lib/IRelay.sol
@@ -21,8 +21,10 @@ interface IRelay {
     error ErrDepositAmountNotEqualToRequiredAmount();
     error ErrRelayNotLocked();
     error ErrSenderNotPayer();
+    error ErrSenderNotPayee();
     error ErrRelayAlreadyApprovedOrReturned();
     error ErrNotAfterAllowReturnTimestamp();
+    error ErrNotPastUnlockTime();
 
     /// @notice Gets information about the actors involved in the relay agreement.
     /// ---

--- a/lib/IRelay.sol
+++ b/lib/IRelay.sol
@@ -21,7 +21,8 @@ interface IRelay {
     error ErrDepositAmountNotEqualToRequiredAmount();
     error ErrRelayNotLocked();
     error ErrSenderNotPayer();
-    error ErrRelayCanNotBeApprovedOrReturned();
+    error ErrRelayAlreadyApprovedOrReturned();
+    error ErrNotAfterAllowReturnTimestamp();
 
     /// @notice Gets information about the actors involved in the relay agreement.
     /// ---

--- a/lib/IRelay.sol
+++ b/lib/IRelay.sol
@@ -11,6 +11,14 @@ interface IRelay {
     event RelayApproved(address indexed _creator, uint indexed _agreementIndex);
     event RelayReturned(address indexed _creator, uint indexed _agreementIndex);
 
+    error ErrSenderNotPayerOrPayee();
+    error ErrPayerEqualsPayee();
+    error ErrRequiredBalanceNotGreaterThanZero();
+    error ErrPayerHasZeroAddress();
+    error ErrPayeeHasZeroAddress();
+    error ErrUnlockAtNotInFuture();
+    error ErrUnlockAtNotGreaterThanReturnAfter();
+
     /// @notice Gets information about the actors involved in the relay agreement.
     /// ---
     /// @param _creator The address of the account which created the agreement.

--- a/lib/IRelay.sol
+++ b/lib/IRelay.sol
@@ -18,6 +18,7 @@ interface IRelay {
     error ErrPayeeHasZeroAddress();
     error ErrUnlockAtNotInFuture();
     error ErrUnlockAtNotGreaterThanReturnAfter();
+    error ErrDepositAmountNotEqualToRequiredAmount();
 
     /// @notice Gets information about the actors involved in the relay agreement.
     /// ---

--- a/lib/IRelay.sol
+++ b/lib/IRelay.sol
@@ -19,6 +19,9 @@ interface IRelay {
     error ErrUnlockAtNotInFuture();
     error ErrUnlockAtNotGreaterThanReturnAfter();
     error ErrDepositAmountNotEqualToRequiredAmount();
+    error ErrRelayNotLocked();
+    error ErrSenderNotPayer();
+    error ErrRelayCanNotBeApprovedOrReturned();
 
     /// @notice Gets information about the actors involved in the relay agreement.
     /// ---

--- a/lib/RelayBase.sol
+++ b/lib/RelayBase.sol
@@ -63,9 +63,9 @@ abstract contract RelayBase is IRelay {
 
     function approveRelay(address _creator, uint _index) external virtual override {
         EscrowStructs.Relay storage relay = relays[_creator][_index];
-        require(relay.isLocked, "TimeLockRelay: relay must be locked before approval");
-        require(msg.sender == relay.payer, "TimeLockRelay: only the payer can approve the relay");
-        require(!relay.isApproved && !relay.isReturning, "TimeLockRelay: relay is already approved or returned");
+        require(relay.isLocked, ErrRelayNotLocked());
+        require(msg.sender == relay.payer, ErrSenderNotPayer());
+        require(!relay.isApproved && !relay.isReturning, ErrRelayCanNotBeApprovedOrReturned());
 
         relay.isApproved = true;
 

--- a/lib/RelayBase.sol
+++ b/lib/RelayBase.sol
@@ -65,7 +65,7 @@ abstract contract RelayBase is IRelay {
         EscrowStructs.Relay storage relay = relays[_creator][_index];
         require(relay.isLocked, ErrRelayNotLocked());
         require(msg.sender == relay.payer, ErrSenderNotPayer());
-        require(!relay.isApproved && !relay.isReturning, ErrRelayCanNotBeApprovedOrReturned());
+        require(!relay.isApproved && !relay.isReturning, ErrRelayAlreadyApprovedOrReturned());
 
         relay.isApproved = true;
 

--- a/lib/RelayBase.sol
+++ b/lib/RelayBase.sol
@@ -50,7 +50,7 @@ abstract contract RelayBase is IRelay {
     function depositFunds(address _creator, uint _index) external override payable {
         EscrowStructs.Relay storage relay = relays[_creator][_index];
 
-        require(msg.value == relay.requiredBalance, "TransactionRelay: deposit amount must equal the required balance");
+        require(msg.value == relay.requiredBalance, ErrDepositAmountNotEqualToRequiredAmount());
         relay.currentBalance += msg.value;
         relay.isLocked = true; // Lock the relay after deposit
 

--- a/lib/UndisputableRelayBase.sol
+++ b/lib/UndisputableRelayBase.sol
@@ -11,13 +11,13 @@ abstract contract UndisputableRelayBase is RelayBase, IUndisputableRelay {
     constructor(string memory _symbol, uint _basisPointFee) RelayBase(_symbol, _basisPointFee) {}
 
     function createRelay(uint _requiredBalance, address _payer, address _payee, uint _automaticallyUnlockAt, uint _allowReturnAfter) public virtual override {
-        require(msg.sender == _payer || msg.sender == _payee, "TransactionRelay: only the payer or payee can create a relay");
-        require(_payer != _payee, "TransactionRelay: payer and payee must be different addresses");
-        require(_requiredBalance > 0, "TransactionRelay: required balance must be greater than 0");
-        require(_payer != address(0), "TransactionRelay: payer address must not be 0x0");
-        require(_payee != address(0), "TransactionRelay: payee address must not be 0x0");
-        require(_automaticallyUnlockAt > block.timestamp, "TransactionRelay: automatically approved at timestamp must be in the future");
-        require(_automaticallyUnlockAt > _allowReturnAfter, "TransactionRelay: automatically approved at timestamp must be after allow return after timestamp");
+        require(msg.sender == _payer || msg.sender == _payee, ErrSenderNotPayerOrPayee());
+        require(_payer != _payee, ErrPayerEqualsPayee());
+        require(_requiredBalance > 0, ErrRequiredBalanceNotGreaterThanZero());
+        require(_payer != address(0), ErrPayerHasZeroAddress());
+        require(_payee != address(0), ErrPayeeHasZeroAddress());
+        require(_automaticallyUnlockAt > block.timestamp, ErrUnlockAtNotInFuture());
+        require(_automaticallyUnlockAt > _allowReturnAfter, ErrUnlockAtNotGreaterThanReturnAfter());
 
         relays[msg.sender].push(
             EscrowStructs.Relay({

--- a/lib/UndisputableRelayBase.sol
+++ b/lib/UndisputableRelayBase.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GNU-3.0
 pragma solidity ^0.8.23;
 
-import "./EscrowStructs.sol";
+import {EscrowStructs} from "./EscrowStructs.sol";
 import {IRelay} from "./IRelay.sol";
 import {IUndisputableRelay} from "./IUndisputableRelay.sol";
 import {RelayBase} from "./RelayBase.sol";
@@ -84,17 +84,15 @@ abstract contract UndisputableRelayBase is RelayBase, IUndisputableRelay {
     function _validateWithdrawal(address _creator, uint _index) internal view {
         EscrowStructs.Relay storage relay = relays[_creator][_index];
 
-        if (relay.isLocked) {
-            if (relay.isReturning) {
-                require(relay.payer == msg.sender, "TransactionRelay: only the payer can withdraw funds (if marked as returning)");
-            } else if (relay.isApproved) {
-                require(relay.payee == msg.sender, "TransactionRelay: only the payee can withdraw funds (if locked and approved)");
-            } else {
-                require(_isPassedAutomaticUnlockTime(_creator, _index), "TransactionRelay: can not withdraw funds if not approved and not passed automatic approval time");
-                require(relay.payee == msg.sender, "TransactionRelay: only the payee can withdraw funds (if locked and not approved)");
-            }
+        if (!relay.isLocked) {
+            revert ErrRelayNotLocked();
+        } else if (relay.isApproved) {
+            require(relay.payee == msg.sender, ErrSenderNotPayee());
+        } else if (relay.isReturning) {
+            require(relay.payer == msg.sender, ErrSenderNotPayer());
         } else {
-            revert("TransactionRelay: can not withdraw funds if relay isn't locked");
+            require(_isPassedAutomaticUnlockTime(_creator, _index), ErrNotPastUnlockTime());
+            require(relay.payee == msg.sender, ErrSenderNotPayee());
         }
     }
 
@@ -103,8 +101,8 @@ abstract contract UndisputableRelayBase is RelayBase, IUndisputableRelay {
         uint platformFee = 0;
         uint grossAmount = 0;
 
-        // If the relay is not locked, the full amount can be withdrawn
-        if (relay.isLocked && (relay.isReturning || relay.isApproved)) {
+        // If the relay is returned or approved or if the automatic unlock time has passed
+        if (relay.isApproved || relay.isReturning || _isPassedAutomaticUnlockTime(_creator, _index)) {
             platformFee = _calculateBasisPointProportion(relay.currentBalance, basisPointFee);
             grossAmount = relay.currentBalance - platformFee;
         }

--- a/test/CreateDiscretionaryRelay.t.sol
+++ b/test/CreateDiscretionaryRelay.t.sol
@@ -1,22 +1,31 @@
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
+import "../lib/IRelay.sol";
+import {CommonBase} from "../lib/forge-std/src/Base.sol";
 import {DiscretionaryRelay} from "../lib/DiscretionaryRelay.sol";
+import {StdAssertions} from "../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../lib/forge-std/src/StdUtils.sol";
+import {Test} from "../lib/forge-std/src/Test.sol";
 
 contract CreateDiscretionaryRelayTest is Test {
     DiscretionaryRelay public relay;
     address public alice = address(0xA11CE);
     address public bob = address(0xB0B);
+    address public dee = address(0xDEE);
 
     function setUp() public {
         relay = new DiscretionaryRelay("ETH", 100);
     }
 
     function testCreateRelayHappyPath() public {
-        uint requiredBalance = 1_000_000_000_000_000_000 ; // 1 ETH in wei
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
         uint unlockAt = block.timestamp + 10 days;
         uint allowReturnAfter = block.timestamp + 5 days;
         vm.prank(alice);
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.RelayCreated(alice, 0, alice, bob);
 
         relay.createRelay(
             requiredBalance,
@@ -31,9 +40,119 @@ contract CreateDiscretionaryRelayTest is Test {
         assertEq(payee, bob);
         assertEq(creator, alice);
         assertTrue(initialized);
-//        assertEq(relay.relays[alice][0].payer, alice);
-//        assertEq(relay.relays[alice][0].payee, bob);
-//        assertEq(relay.relays[alice][0].automaticallyUnlockAt, unlockAt);
-//        assertEq(relay.relays[alice][0].allowReturnAfter, allowReturnAfter);
+    }
+
+    function testCreateRelayRevertsWhenPayerAndPayeeAreSame() public {
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = block.timestamp + 10 days;
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrPayerEqualsPayee.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            alice, // Same address for payer and payee
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenRequiredBalanceIsZero() public {
+        uint requiredBalance = 0; // 0 ETH in wei
+        uint unlockAt = block.timestamp + 10 days;
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrRequiredBalanceNotGreaterThanZero.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            bob,
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenSenderIsNotPayerOrPayee() public {
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = block.timestamp + 10 days;
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrSenderNotPayerOrPayee.selector);
+        vm.prank(dee); // Dee is not the payer or payee
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            bob,
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenPayerIsZeroAddress() public {
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = block.timestamp + 10 days;
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrPayerHasZeroAddress.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            address(0), // Zero address for payer
+            alice,
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenPayeeIsZeroAddress() public {
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = block.timestamp + 10 days;
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrPayeeHasZeroAddress.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            address(0), // Zero address for payee
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenAutomaticallyApprovedAtInPast() public {
+        uint currentTimestamp = 4102444800; // 2100/01/01 00:00:00 GMT
+        vm.warp(currentTimestamp); // Set the current block timestamp
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = 946684800; // In the past – 2000/01/01 00:00:00 GMT
+        uint allowReturnAfter = block.timestamp + 5 days;
+
+        vm.expectRevert(IRelay.ErrUnlockAtNotInFuture.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            bob,
+            unlockAt,
+            allowReturnAfter
+        );
+    }
+
+    function testCreateRelayRevertsWhenAutomaticallyApprovedAtLessThanAllowReturnAfter() public {
+        uint requiredBalance = 1_000_000_000_000_000_000; // 1 ETH in wei
+        uint unlockAt = block.timestamp + 5 days; // Automatically approved at
+        uint allowReturnAfter = block.timestamp + 10 days; // Allow return after
+
+        vm.expectRevert(IRelay.ErrUnlockAtNotGreaterThanReturnAfter.selector);
+        vm.prank(alice);
+        relay.createRelay(
+            requiredBalance,
+            alice,
+            bob,
+            unlockAt,
+            allowReturnAfter
+        );
     }
 }

--- a/test/discretionary-relay/ApproveRelay.t.sol
+++ b/test/discretionary-relay/ApproveRelay.t.sol
@@ -16,12 +16,12 @@ contract DiscretionaryRelayApproveRelayTest is DiscretionaryRelayTest {
     function setUp() public override {
         DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
         // Create the relay
-        createDiscretionaryRelay(
+        _createDiscretionaryRelay(
             requiredAmount,
             alice,
             bob,
-            getUnlockAt(),
-            getReturnAfter(),
+            _getUnlockAt(),
+            _getReturnAfter(),
             alice
         );
     }
@@ -42,8 +42,8 @@ contract DiscretionaryRelayApproveRelayTest is DiscretionaryRelayTest {
         assertTrue(isLocked);
         assertFalse(isReturning);
         assertTrue(isApproved); // The relay should be approved after approval
-        assertEq(automaticallyUnlockAt, getUnlockAt());
-        assertEq(allowReturnAfter, getReturnAfter());
+        assertEq(automaticallyUnlockAt, _getUnlockAt());
+        assertEq(allowReturnAfter, _getReturnAfter());
         assertTrue(isInitialized);
     }
 
@@ -84,7 +84,7 @@ contract DiscretionaryRelayApproveRelayTest is DiscretionaryRelayTest {
     function testApproveRelayRevertsIfRelayReturning() public {
         _depositFunds();
 
-        vm.warp(getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
         vm.prank(alice);
         relay.returnRelay(alice, 0); // Return the relay first
 

--- a/test/discretionary-relay/ApproveRelay.t.sol
+++ b/test/discretionary-relay/ApproveRelay.t.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
+import {IRelay} from "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
+
+
+contract DiscretionaryRelayApproveRelayTest is DiscretionaryRelayTest {
+    uint public requiredAmount = 1_000_000_000_000_000_000; // 1 ETH in wei
+
+    function setUp() public override {
+        DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
+        // Create the relay
+        createDiscretionaryRelay(
+            requiredAmount,
+            alice,
+            bob,
+            getUnlockAt(),
+            getReturnAfter(),
+            alice
+        );
+    }
+
+    function testApproveRelayHappyPath() public {
+        _depositFunds();
+
+        vm.prank(alice);
+        // Expect the RelayApproved event to be emitted
+        vm.expectEmit(true, true, false, false);
+        emit IRelay.RelayApproved(alice, 0);
+        // Alice approves the relay
+        relay.approveRelay(
+            alice,
+            0
+        );
+        (bool isLocked, bool isReturning, bool isApproved, uint automaticallyUnlockAt, uint allowReturnAfter, bool isInitialized) = relay.getRelayState(alice, 0);
+        assertTrue(isLocked);
+        assertFalse(isReturning);
+        assertTrue(isApproved); // The relay should be approved after approval
+        assertEq(automaticallyUnlockAt, getUnlockAt());
+        assertEq(allowReturnAfter, getReturnAfter());
+        assertTrue(isInitialized);
+    }
+
+    function testApproveRelayRevertsIfRelayNotLocked() public {
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrRelayNotLocked.selector);
+        relay.approveRelay(
+            alice,
+            0
+        );
+    }
+
+    function testApproveRelayRevertsIfRelayAlreadyApproved() public {
+        _depositFunds();
+
+        vm.prank(alice);
+        relay.approveRelay(alice, 0); // Approve the relay first
+
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrRelayCanNotBeApprovedOrReturned.selector);
+        relay.approveRelay(
+            alice,
+            0
+        );
+    }
+
+    function testApproveRelayRevertsIfSenderNotPayer() public {
+        _depositFunds();
+
+        vm.prank(bob); // Bob tries to approve the relay
+        vm.expectRevert(IRelay.ErrSenderNotPayer.selector);
+        relay.approveRelay(
+            alice,
+            0
+        );
+    }
+
+    function testApproveRelayRevertsIfRelayReturning() public {
+        _depositFunds();
+
+        vm.warp(getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        vm.prank(alice);
+        relay.returnRelay(alice, 0); // Return the relay first
+
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrRelayCanNotBeApprovedOrReturned.selector);
+        relay.approveRelay(
+            alice,
+            0
+        );
+    }
+
+    function _depositFunds() private {
+        // Alice deposit the funds
+        vm.prank(alice);
+        relay.depositFunds{value: requiredAmount}(alice, 0);
+    }
+}

--- a/test/discretionary-relay/CreateRelay.t.sol
+++ b/test/discretionary-relay/CreateRelay.t.sol
@@ -23,16 +23,16 @@ contract DiscretionaryRelayCreateRelayTest is DiscretionaryRelayTest {
         uint unlockAt = block.timestamp + 10 days;
         uint returnAfter = block.timestamp + 5 days;
 
-        vm.prank(alice);
         vm.expectEmit(true, true, false, true);
         emit IRelay.RelayCreated(alice, 0, alice, bob);
 
-        relay.createRelay(
+        createDiscretionaryRelay(
             requiredAmount,
             alice,
             bob,
             unlockAt,
-            returnAfter
+            returnAfter,
+            alice
         );
 
         (address payer, address payee, address creator, bool isInitialized1) = relay.getRelayActors(alice, 0);

--- a/test/discretionary-relay/CreateRelay.t.sol
+++ b/test/discretionary-relay/CreateRelay.t.sol
@@ -1,15 +1,15 @@
 pragma solidity ^0.8.20;
 
-import "../lib/IRelay.sol";
-import {CommonBase} from "../lib/forge-std/src/Base.sol";
-import {DiscretionaryRelay} from "../lib/DiscretionaryRelay.sol";
-import {StdAssertions} from "../lib/forge-std/src/StdAssertions.sol";
-import {StdChains} from "../lib/forge-std/src/StdChains.sol";
-import {StdCheats, StdCheatsSafe} from "../lib/forge-std/src/StdCheats.sol";
-import {StdUtils} from "../lib/forge-std/src/StdUtils.sol";
-import {Test} from "../lib/forge-std/src/Test.sol";
+import "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {Test} from "../../lib/forge-std/src/Test.sol";
 
-contract CreateDiscretionaryRelayTest is Test {
+contract DiscretionaryRelayCreateRelayTest is Test {
     DiscretionaryRelay public relay;
     address public alice = address(0xA11CE);
     address public bob = address(0xB0B);

--- a/test/discretionary-relay/CreateRelay.t.sol
+++ b/test/discretionary-relay/CreateRelay.t.sol
@@ -26,7 +26,7 @@ contract DiscretionaryRelayCreateRelayTest is DiscretionaryRelayTest {
         vm.expectEmit(true, true, false, true);
         emit IRelay.RelayCreated(alice, 0, alice, bob);
 
-        createDiscretionaryRelay(
+        _createDiscretionaryRelay(
             requiredAmount,
             alice,
             bob,

--- a/test/discretionary-relay/CreateRelay.t.sol
+++ b/test/discretionary-relay/CreateRelay.t.sol
@@ -1,4 +1,6 @@
-pragma solidity ^0.8.20;
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
 
 import "../../lib/IRelay.sol";
 import {CommonBase} from "../../lib/forge-std/src/Base.sol";
@@ -9,17 +11,11 @@ import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
 import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
 import {Test} from "../../lib/forge-std/src/Test.sol";
 import {console} from "../../lib/forge-std/src/console.sol";
+import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
 
-contract DiscretionaryRelayCreateRelayTest is Test {
-    DiscretionaryRelay public relay;
-    address public alice = address(0xA11CE);
-    address public bob = address(0xB0B);
-    address public dee = address(0xDEE);
-    uint public currentBlockTimestamp = 4102444800; // 2100/01/01 00:00:00 GMT
-
-    function setUp() public {
-        relay = new DiscretionaryRelay("ETH", 100);
-        vm.warp(currentBlockTimestamp); // Set the current block timestamp
+contract DiscretionaryRelayCreateRelayTest is DiscretionaryRelayTest {
+    function setUp() public override {
+        DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
     }
 
     function testCreateRelayHappyPath() public {

--- a/test/discretionary-relay/DepositFunds.t.sol
+++ b/test/discretionary-relay/DepositFunds.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
+import {IRelay} from "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
+
+
+contract DiscretionaryRelayDepositFundsTest is DiscretionaryRelayTest {
+    uint public requiredAmount = 1_000_000_000_000_000_000; // 1 ETH in wei
+
+
+    function setUp() public override {
+        DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
+        // Create the relay
+        createDiscretionaryRelay(
+            requiredAmount,
+            alice,
+            bob,
+            getUnlockAt(),
+            getReturnAfter(),
+            alice
+        );
+    }
+
+    function testDepositFundsHappyPath() public {
+        // Deposit funds into the relay
+        uint depositAmount = requiredAmount;
+        // Expect the FundsDeposited event to be emitted
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.FundsDeposited(alice, 0, depositAmount, depositAmount, depositAmount);
+        // Alice deposit the funds
+        vm.prank(alice);
+        relay.depositFunds{value: depositAmount}(alice, 0);
+        // Check the relay balances
+        (uint requiredBalance2, uint currentBalance2, bool isInitialized4) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance2, depositAmount);
+        assertEq(currentBalance2, depositAmount);
+        assertTrue(isInitialized4);
+        (bool isLocked2, bool isReturning2, bool isApproved2, uint automaticallyUnlockAt2, uint allowReturnAfter2, bool isInitialized5) = relay.getRelayState(alice, 0);
+        assertTrue(isLocked2); // The relay should be locked after deposit
+        assertFalse(isReturning2);
+        assertFalse(isApproved2);
+        assertEq(automaticallyUnlockAt2, getUnlockAt());
+        assertEq(allowReturnAfter2, getReturnAfter());
+        assertTrue(isInitialized5);
+    }
+
+    function testDepositFundsRevertsWhenFundsDepositedNotEqualToRequiredBalance() public {
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrDepositAmountNotEqualToRequiredAmount.selector);
+        relay.depositFunds{value: requiredAmount + 1}(alice, 0);
+    }
+
+    function getUnlockAt() private view returns (uint) {
+        return block.timestamp + 10 days;
+    }
+
+    function getReturnAfter() private view returns (uint) {
+        return block.timestamp + 5 days;
+    }
+}

--- a/test/discretionary-relay/DepositFunds.t.sol
+++ b/test/discretionary-relay/DepositFunds.t.sol
@@ -13,7 +13,6 @@ import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
 contract DiscretionaryRelayDepositFundsTest is DiscretionaryRelayTest {
     uint public requiredAmount = 1_000_000_000_000_000_000; // 1 ETH in wei
 
-
     function setUp() public override {
         DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
         // Create the relay
@@ -54,13 +53,5 @@ contract DiscretionaryRelayDepositFundsTest is DiscretionaryRelayTest {
         vm.prank(alice);
         vm.expectRevert(IRelay.ErrDepositAmountNotEqualToRequiredAmount.selector);
         relay.depositFunds{value: requiredAmount + 1}(alice, 0);
-    }
-
-    function getUnlockAt() private view returns (uint) {
-        return block.timestamp + 10 days;
-    }
-
-    function getReturnAfter() private view returns (uint) {
-        return block.timestamp + 5 days;
     }
 }

--- a/test/discretionary-relay/DepositFunds.t.sol
+++ b/test/discretionary-relay/DepositFunds.t.sol
@@ -16,12 +16,12 @@ contract DiscretionaryRelayDepositFundsTest is DiscretionaryRelayTest {
     function setUp() public override {
         DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
         // Create the relay
-        createDiscretionaryRelay(
+        _createDiscretionaryRelay(
             requiredAmount,
             alice,
             bob,
-            getUnlockAt(),
-            getReturnAfter(),
+            _getUnlockAt(),
+            _getReturnAfter(),
             alice
         );
     }
@@ -44,8 +44,8 @@ contract DiscretionaryRelayDepositFundsTest is DiscretionaryRelayTest {
         assertTrue(isLocked2); // The relay should be locked after deposit
         assertFalse(isReturning2);
         assertFalse(isApproved2);
-        assertEq(automaticallyUnlockAt2, getUnlockAt());
-        assertEq(allowReturnAfter2, getReturnAfter());
+        assertEq(automaticallyUnlockAt2, _getUnlockAt());
+        assertEq(allowReturnAfter2, _getReturnAfter());
         assertTrue(isInitialized5);
     }
 

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -7,7 +7,7 @@ import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
 
 abstract contract DiscretionaryRelayTest is Test {
     DiscretionaryRelay public relay;
-    address public owner = address(0x0bcE5);
+    address public owner = address(0xb055);
     address public alice = address(0xA11CE);
     address public bob = address(0xB0B);
     address public dee = address(0xDEE);

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
+
+import {Test} from "../../lib/forge-std/src/Test.sol";
+import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
+
+abstract contract DiscretionaryRelayTest is Test {
+    DiscretionaryRelay public relay;
+    address public alice = address(0xA11CE);
+    address public bob = address(0xB0B);
+    address public dee = address(0xDEE);
+    uint public currentBlockTimestamp = 4102444800; // 2100/01/01 00:00:00 GMT
+
+    function setUp() public virtual {
+        relay = new DiscretionaryRelay("ETH", 100);
+        vm.warp(currentBlockTimestamp); // Set the current block timestamp
+    }
+
+    function testIsDisputable() public view {
+        bool isDisputable = relay.isDisputable();
+        assertEq(isDisputable, false);
+    }
+}

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -41,4 +41,8 @@ abstract contract DiscretionaryRelayTest is Test {
     function _getReturnAfter() internal view returns (uint) {
         return currentBlockTimestamp + 5 days;
     }
+
+    function _calculateBasisPointProportion(uint _amount, uint basisPoints) internal pure returns (uint) {
+        return (_amount * basisPoints) / 10000;
+    }
 }

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -33,4 +33,12 @@ abstract contract DiscretionaryRelayTest is Test {
             _allowReturnAfter
         );
     }
+
+    function getUnlockAt() internal view returns (uint) {
+        return block.timestamp + 10 days;
+    }
+
+    function getReturnAfter() internal view returns (uint) {
+        return block.timestamp + 5 days;
+    }
 }

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -7,12 +7,14 @@ import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
 
 abstract contract DiscretionaryRelayTest is Test {
     DiscretionaryRelay public relay;
+    address public owner = address(0x0bcE5);
     address public alice = address(0xA11CE);
     address public bob = address(0xB0B);
     address public dee = address(0xDEE);
     uint public currentBlockTimestamp = 4102444800; // 2100/01/01 00:00:00 GMT
 
     function setUp() public virtual {
+        vm.prank(owner);
         relay = new DiscretionaryRelay("ETH", 100);
         vm.warp(currentBlockTimestamp); // Set the current block timestamp
 

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -35,10 +35,10 @@ abstract contract DiscretionaryRelayTest is Test {
     }
 
     function _getUnlockAt() internal view returns (uint) {
-        return block.timestamp + 10 days;
+        return currentBlockTimestamp + 10 days;
     }
 
     function _getReturnAfter() internal view returns (uint) {
-        return block.timestamp + 5 days;
+        return currentBlockTimestamp + 5 days;
     }
 }

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -22,7 +22,7 @@ abstract contract DiscretionaryRelayTest is Test {
         vm.deal(dee, 10_000_000_000_000_000_000);
     }
 
-    function createDiscretionaryRelay(uint _requiredBalance, address _payer, address _payee, uint _automaticallyUnlockAt, uint _allowReturnAfter, address _creator) public {
+    function _createDiscretionaryRelay(uint _requiredBalance, address _payer, address _payee, uint _automaticallyUnlockAt, uint _allowReturnAfter, address _creator) internal {
         vm.prank(_creator);
 
         relay.createRelay(
@@ -34,11 +34,11 @@ abstract contract DiscretionaryRelayTest is Test {
         );
     }
 
-    function getUnlockAt() internal view returns (uint) {
+    function _getUnlockAt() internal view returns (uint) {
         return block.timestamp + 10 days;
     }
 
-    function getReturnAfter() internal view returns (uint) {
+    function _getReturnAfter() internal view returns (uint) {
         return block.timestamp + 5 days;
     }
 }

--- a/test/discretionary-relay/DiscretionaryRelayTest.t.sol
+++ b/test/discretionary-relay/DiscretionaryRelayTest.t.sol
@@ -15,10 +15,22 @@ abstract contract DiscretionaryRelayTest is Test {
     function setUp() public virtual {
         relay = new DiscretionaryRelay("ETH", 100);
         vm.warp(currentBlockTimestamp); // Set the current block timestamp
+
+        // Fund the addresses with some ether for testing – 10 ETH for each
+        vm.deal(alice, 10_000_000_000_000_000_000);
+        vm.deal(bob, 10_000_000_000_000_000_000);
+        vm.deal(dee, 10_000_000_000_000_000_000);
     }
 
-    function testIsDisputable() public view {
-        bool isDisputable = relay.isDisputable();
-        assertEq(isDisputable, false);
+    function createDiscretionaryRelay(uint _requiredBalance, address _payer, address _payee, uint _automaticallyUnlockAt, uint _allowReturnAfter, address _creator) public {
+        vm.prank(_creator);
+
+        relay.createRelay(
+            _requiredBalance,
+            _payer,
+            _payee,
+            _automaticallyUnlockAt,
+            _allowReturnAfter
+        );
     }
 }

--- a/test/discretionary-relay/IsDisputable.t.sol
+++ b/test/discretionary-relay/IsDisputable.t.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.20;
 
 import "../../lib/IRelay.sol";
+import "./DiscretionaryRelayTest.t.sol";
 import {CommonBase} from "../../lib/forge-std/src/Base.sol";
 import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
 import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
@@ -9,14 +10,8 @@ import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
 import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
 import {Test} from "../../lib/forge-std/src/Test.sol";
 
-contract DiscretionaryRelayIsDisputableTest is Test {
-    DiscretionaryRelay public relay;
-
-    function setUp() public {
-        relay = new DiscretionaryRelay("ETH", 100);
-    }
-
-    function testIsDisputable() public {
+contract DiscretionaryRelayIsDisputableTest is DiscretionaryRelayTest {
+    function testIsDisputable() public view {
         bool isDisputable = relay.isDisputable();
         assertEq(isDisputable, false);
     }

--- a/test/discretionary-relay/IsDisputable.t.sol
+++ b/test/discretionary-relay/IsDisputable.t.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.20;
+
+import "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {DiscretionaryRelay} from "../../lib/DiscretionaryRelay.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {Test} from "../../lib/forge-std/src/Test.sol";
+
+contract DiscretionaryRelayIsDisputableTest is Test {
+    DiscretionaryRelay public relay;
+
+    function setUp() public {
+        relay = new DiscretionaryRelay("ETH", 100);
+    }
+
+    function testIsDisputable() public {
+        bool isDisputable = relay.isDisputable();
+        assertEq(isDisputable, false);
+    }
+}

--- a/test/discretionary-relay/StashFunds.t.sol
+++ b/test/discretionary-relay/StashFunds.t.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
+import {IRelay} from "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
+import {console} from "../../lib/forge-std/src/console.sol";
+
+
+contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
+    uint public requiredAmount = 1_000_000_000_000_000_000; // 1 ETH in wei
+
+    function setUp() public override {
+        DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
+        // Create the relay
+        _createDiscretionaryRelay(
+            requiredAmount,
+            alice,
+            bob,
+            _getUnlockAt(),
+            _getReturnAfter(),
+            alice
+        );
+    }
+
+    function testStashFundsAfterApprovalHappyPath() public {
+        _depositFunds();
+
+        // Payer approves relay
+        vm.prank(alice);
+        relay.approveRelay(
+            alice,
+            0
+        );
+
+        // Payee's account balance should be zero before stashing
+        uint accountBalanceBeforeStash = relay.accountBalances(bob);
+        assertEq(accountBalanceBeforeStash, 0, "Payee's account balance should be zero before stashing");
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the RelayApproved event to be emitted
+        vm.expectEmit(true, true, false, false);
+        emit IRelay.FundsStashed(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payee stashes funds
+        vm.prank(bob);
+        relay.stashFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payee
+        uint accountBalance = relay.accountBalances(bob);
+        assertEq(accountBalance, expectedPayeeAmount, "Payee's account balance should match the expected amount");
+    }
+
+    function testStashFundsAfterReturnHappyPath() public {
+        _depositFunds();
+
+        // Payer returns relay
+        vm.prank(alice);
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        relay.returnRelay(
+            alice,
+            0
+        );
+
+        // Payee's account balance should be zero before stashing
+        uint accountBalanceBeforeStash = relay.accountBalances(alice);
+        assertEq(accountBalanceBeforeStash, 0, "Payer's account balance should be zero before stashing");
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the RelayApproved event to be emitted
+        vm.expectEmit(true, true, false, false);
+        emit IRelay.FundsStashed(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payer stashes funds
+        vm.prank(alice);
+        relay.stashFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payer
+        uint accountBalance = relay.accountBalances(alice);
+        assertEq(accountBalance, expectedPayeeAmount, "Payer's account balance should match the expected amount");
+    }
+
+    function testStashFundsAfterUnlockTime() public {
+        _depositFunds();
+
+        // Time passes the unlock time
+        vm.warp(_getUnlockAt() + 1);
+
+        // Payee's account balance should be zero before stashing
+        uint accountBalanceBeforeStash = relay.accountBalances(bob);
+        assertEq(accountBalanceBeforeStash, 0, "Payee's account balance should be zero before stashing");
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the RelayApproved event to be emitted
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.FundsStashed(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payer can stash funds without approval because passed the unlock time
+        vm.prank(bob);
+        relay.stashFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payee
+        uint accountBalance = relay.accountBalances(bob);
+        assertEq(accountBalance, expectedPayeeAmount, "Payee's account balance should match the expected amount");
+    }
+
+    function testStashFundsRevertsIfRelayNotLocked() public {
+        vm.prank(bob);
+        vm.expectRevert(IRelay.ErrRelayNotLocked.selector);
+        relay.stashFunds(
+            alice,
+            0
+        );
+    }
+
+    function testStashFundsRevertsIfRelayIsApprovedAndSenderIsNotPayee() public {
+        _depositFunds();
+
+        // Payer approves relay
+        vm.prank(alice);
+        relay.approveRelay(
+            alice,
+            0
+        );
+
+        // Alice tries to stash funds, but she is not the payee (she is the payer)
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.stashFunds(
+            alice,
+            0
+        );
+
+        // Dee tries to stash funds, but she is not the payee (she is not involved in the relay)
+        vm.prank(dee);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.stashFunds(
+            alice,
+            0
+        );
+    }
+
+    function testStashFundsRevertsIfRelayIsReturnedAndSenderIsNotPayer() public {
+        _depositFunds();
+
+        // Payer returns relay
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        vm.prank(alice);
+        relay.returnRelay(
+            alice,
+            0
+        );
+
+        // Bob tries to stash funds after they have been returned to the payer, but he is not the payer (he is the payee)
+        vm.prank(bob);
+        vm.expectRevert(IRelay.ErrSenderNotPayer.selector);
+        relay.stashFunds(
+            alice,
+            0
+        );
+
+        // Dee tries to stash funds after they have been returned to the payer, but she is not the payer (she is not involved in the relay)
+        vm.prank(dee);
+        vm.expectRevert(IRelay.ErrSenderNotPayer.selector);
+        relay.stashFunds(
+            alice,
+            0
+        );
+    }
+
+    function testApproveRelayRevertsIfAlreadyReturned() public {
+        _depositFunds();
+
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        vm.prank(alice);
+        relay.returnRelay(alice, 0); // Return the relay first
+
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrRelayAlreadyApprovedOrReturned.selector);
+        relay.approveRelay(
+            alice,
+            0
+        );
+    }
+
+    function _depositFunds() private {
+        // Alice deposit the funds
+        vm.prank(alice);
+        relay.depositFunds{value: requiredAmount}(alice, 0);
+    }
+}

--- a/test/discretionary-relay/StashFunds.t.sol
+++ b/test/discretionary-relay/StashFunds.t.sol
@@ -41,6 +41,9 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         uint accountBalanceBeforeStash = relay.accountBalances(bob);
         assertEq(accountBalanceBeforeStash, 0, "Payee's account balance should be zero before stashing");
 
+        // Check the wallet balance of the payee before stashing
+        uint initialWalletBalance = bob.balance;
+
         // Calculate expected amounts
         uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
         uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
@@ -58,10 +61,18 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         // Check the new account balance of the payee
         uint accountBalance = relay.accountBalances(bob);
         assertEq(accountBalance, expectedPayeeAmount, "Payee's account balance should match the expected amount");
+        // Check the wallet balance of the payee
+        assertEq(bob.balance, initialWalletBalance, "Payee's wallet balance should remain unchanged after stashing funds");
 
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after stashing");
+        assertEq(currentBalance, 0, "Current balance should be zero after stashing");
+        assertTrue(isInitialized, "Relay balances should be initialized after stashing");
     }
 
     function testStashFundsAfterReturnHappyPath() public {
@@ -78,6 +89,8 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         // Payer's account balance should be zero before stashing
         uint accountBalanceBeforeStash = relay.accountBalances(alice);
         assertEq(accountBalanceBeforeStash, 0, "Payer's account balance should be zero before stashing");
+        // Check the wallet balance of the payee before stashing
+        uint initialWalletBalance = alice.balance;
 
         // Calculate expected amounts
         uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
@@ -96,10 +109,18 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         // Check the new account balance of the payer
         uint accountBalance = relay.accountBalances(alice);
         assertEq(accountBalance, expectedPayeeAmount, "Payer's account balance should match the expected amount");
+        // Check the wallet balance of the payer
+        assertEq(alice.balance, initialWalletBalance, "Payer's wallet balance should remain unchanged after stashing funds");
 
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after stashing");
+        assertEq(currentBalance, 0, "Current balance should be zero after stashing");
+        assertTrue(isInitialized, "Relay balances should be initialized after stashing");
     }
 
     function testStashFundsAfterUnlockTime() public {
@@ -111,6 +132,8 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         // Payee's account balance should be zero before stashing
         uint accountBalanceBeforeStash = relay.accountBalances(bob);
         assertEq(accountBalanceBeforeStash, 0, "Payee's account balance should be zero before stashing");
+        // Check the wallet balance of the payee before stashing
+        uint initialWalletBalance = bob.balance;
 
         // Calculate expected amounts
         uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
@@ -129,10 +152,18 @@ contract DiscretionaryRelayStashFundsTest is DiscretionaryRelayTest {
         // Check the new account balance of the payee
         uint accountBalance = relay.accountBalances(bob);
         assertEq(accountBalance, expectedPayeeAmount, "Payee's account balance should match the expected amount");
+        // Check the wallet balance of the payee
+        assertEq(bob.balance, initialWalletBalance, "Payee's wallet balance should remain unchanged after stashing funds");
 
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after stashing");
+        assertEq(currentBalance, 0, "Current balance should be zero after stashing");
+        assertTrue(isInitialized, "Relay balances should be initialized after stashing");
     }
 
     function testStashFundsRevertsIfRelayNotLocked() public {

--- a/test/discretionary-relay/WithdrawFunds.t.sol
+++ b/test/discretionary-relay/WithdrawFunds.t.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GNU-3.0
+pragma solidity ^0.8.23;
+
+import {IRelay} from "../../lib/IRelay.sol";
+import {CommonBase} from "../../lib/forge-std/src/Base.sol";
+import {StdAssertions} from "../../lib/forge-std/src/StdAssertions.sol";
+import {StdChains} from "../../lib/forge-std/src/StdChains.sol";
+import {StdCheats, StdCheatsSafe} from "../../lib/forge-std/src/StdCheats.sol";
+import {StdUtils} from "../../lib/forge-std/src/StdUtils.sol";
+import {DiscretionaryRelayTest} from "./DiscretionaryRelayTest.t.sol";
+import {console} from "../../lib/forge-std/src/console.sol";
+
+
+contract DiscretionaryRelayWithdrawFundsTest is DiscretionaryRelayTest {
+    uint public requiredAmount = 1_000_000_000_000_000_000; // 1 ETH in wei
+
+    function setUp() public override {
+        DiscretionaryRelayTest.setUp(); // Call the setup from the base test contract
+        // Create the relay
+        _createDiscretionaryRelay(
+            requiredAmount,
+            alice,
+            bob,
+            _getUnlockAt(),
+            _getReturnAfter(),
+            alice
+        );
+    }
+
+    function testWithdrawFundsAfterApprovalHappyPath() public {
+        _depositFunds();
+
+        // Payer approves relay
+        vm.prank(alice);
+        relay.approveRelay(
+            alice,
+            0
+        );
+
+        // Payee's account balance should be zero before withdrawing
+        uint accountBalanceBeforeWithdraw = relay.accountBalances(bob);
+        assertEq(accountBalanceBeforeWithdraw, 0, "Payee's account balance should be zero before withdrawing");
+
+        // Check the wallet balance of the payee before withdrawing
+        uint initialWalletBalance = bob.balance;
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the event to be emitted
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.FundsWithdrawn(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payee withdraws funds
+        vm.prank(bob);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payee
+        uint accountBalance = relay.accountBalances(bob);
+        assertEq(accountBalance, 0, "Payee's account balance should still be zero after withdrawing funds");
+        // Check the wallet balance of the payee
+        assertEq(bob.balance, initialWalletBalance + expectedPayeeAmount, "Payee's wallet balance should match the expected amount after withdrawing funds");
+
+        // Check the account balance of the contract owner
+        uint ownerAccountBalance = relay.accountBalances(owner);
+        assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+    }
+
+    function testWithdrawFundsAfterReturnHappyPath() public {
+        _depositFunds();
+
+        // Payer returns relay
+        vm.prank(alice);
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        relay.returnRelay(
+            alice,
+            0
+        );
+
+        // Payer's account balance should be zero before withdrawing
+        uint accountBalanceBeforeWithdraw = relay.accountBalances(alice);
+        assertEq(accountBalanceBeforeWithdraw, 0, "Payer's account balance should be zero before withdrawing");
+
+        // Check the wallet balance of the payer before withdrawing
+        uint initialWalletBalance = alice.balance;
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the event to be emitted
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.FundsWithdrawn(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payer withdraws funds
+        vm.prank(alice);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payer
+        uint accountBalance = relay.accountBalances(alice);
+        assertEq(accountBalance, 0, "Payer's account balance should still be zero after withdrawing funds");
+
+        // Check the wallet balance of the payer
+        assertEq(alice.balance, initialWalletBalance + expectedPayeeAmount, "Payer's wallet balance should match the expected amount after withdrawing funds");
+
+        // Check the account balance of the contract owner
+        uint ownerAccountBalance = relay.accountBalances(owner);
+        assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+    }
+
+    function testWithdrawFundsAfterUnlockTime() public {
+        _depositFunds();
+
+        // Time passes the unlock time
+        vm.warp(_getUnlockAt() + 1);
+
+        // Payee's account balance should be zero before withdrawing
+        uint accountBalanceBeforeWithdraw = relay.accountBalances(bob);
+        assertEq(accountBalanceBeforeWithdraw, 0, "Payee's account balance should be zero before withdrawing");
+
+        // Check the wallet balance of the payee before withdrawing
+        uint initialWalletBalance = bob.balance;
+
+        // Calculate expected amounts
+        uint expectedPlatformFee = _calculateBasisPointProportion(requiredAmount, relay.basisPointFee());
+        uint expectedPayeeAmount = requiredAmount - expectedPlatformFee;
+        // Expect the event to be emitted
+        vm.expectEmit(true, true, false, true);
+        emit IRelay.FundsWithdrawn(alice, 0, requiredAmount, expectedPayeeAmount, expectedPlatformFee);
+
+        // Payee can withdraw funds without approval because passed the unlock time
+        vm.prank(bob);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        // Check the new account balance of the payee
+        uint accountBalance = relay.accountBalances(bob);
+        assertEq(accountBalance, 0, "Payee's account balance should still be zero after withdrawing funds");
+
+        // Check the wallet balance of the payee
+        assertEq(bob.balance, initialWalletBalance + expectedPayeeAmount, "Payee's wallet balance should match the expected amount after withdrawing funds");
+
+        // Check the account balance of the contract owner
+        uint ownerAccountBalance = relay.accountBalances(owner);
+        assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+    }
+
+    function testWithdrawFundsRevertsIfRelayNotLocked() public {
+        vm.prank(bob);
+        vm.expectRevert(IRelay.ErrRelayNotLocked.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+    }
+
+    function testWithdrawFundsRevertsIfRelayIsApprovedAndSenderIsNotPayee() public {
+        _depositFunds();
+
+        // Payer approves relay
+        vm.prank(alice);
+        relay.approveRelay(
+            alice,
+            0
+        );
+
+        // Alice tries to withdraw funds, but she is not the payee (she is the payer)
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        // Dee tries to withdraw funds, but she is not the payee (she is not involved in the relay)
+        vm.prank(dee);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+    }
+
+    function testWithdrawFundsRevertsIfRelayIsReturnedAndSenderIsNotPayer() public {
+        _depositFunds();
+
+        // Payer returns relay
+        vm.warp(_getReturnAfter() + 1); // Ensure allowReturnAfter has passed
+        vm.prank(alice);
+        relay.returnRelay(
+            alice,
+            0
+        );
+
+        // Bob tries to withdraw funds after they have been returned to the payer, but he is not the payer (he is the payee)
+        vm.prank(bob);
+        vm.expectRevert(IRelay.ErrSenderNotPayer.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        // Dee tries to withdraw funds after they have been returned to the payer, but she is not the payer (she is not involved in the relay)
+        vm.prank(dee);
+        vm.expectRevert(IRelay.ErrSenderNotPayer.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+    }
+
+    function testWithdrawFundsRevertsIfNotApprovedOrReturnedAndNotPastUnlockTime() public {
+        _depositFunds();
+
+        vm.warp(_getUnlockAt() - 1); // Ensure we are before the unlock time
+
+        vm.prank(bob);
+        vm.expectRevert(IRelay.ErrNotPastUnlockTime.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+    }
+
+    function testWithdrawFundsRevertsIfPastUnlockTimeNotApprovedOrReturnedAndNotPayee() public {
+        _depositFunds();
+
+        vm.warp(_getUnlockAt() + 1); // Ensure we are after the unlock time
+
+        vm.prank(alice);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+
+        vm.prank(dee);
+        vm.expectRevert(IRelay.ErrSenderNotPayee.selector);
+        relay.withdrawFunds(
+            alice,
+            0
+        );
+    }
+
+    function _depositFunds() private {
+        // Alice deposit the funds
+        vm.prank(alice);
+        relay.depositFunds{value: requiredAmount}(alice, 0);
+    }
+}

--- a/test/discretionary-relay/WithdrawFunds.t.sol
+++ b/test/discretionary-relay/WithdrawFunds.t.sol
@@ -67,6 +67,12 @@ contract DiscretionaryRelayWithdrawFundsTest is DiscretionaryRelayTest {
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after withdrawal");
+        assertEq(currentBalance, 0, "Current balance should be zero after withdrawal");
+        assertTrue(isInitialized, "Relay balances should be initialized after withdrawal");
     }
 
     function testWithdrawFundsAfterReturnHappyPath() public {
@@ -111,6 +117,12 @@ contract DiscretionaryRelayWithdrawFundsTest is DiscretionaryRelayTest {
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after withdrawal");
+        assertEq(currentBalance, 0, "Current balance should be zero after withdrawal");
+        assertTrue(isInitialized, "Relay balances should be initialized after withdrawal");
     }
 
     function testWithdrawFundsAfterUnlockTime() public {
@@ -150,6 +162,12 @@ contract DiscretionaryRelayWithdrawFundsTest is DiscretionaryRelayTest {
         // Check the account balance of the contract owner
         uint ownerAccountBalance = relay.accountBalances(owner);
         assertEq(ownerAccountBalance, expectedPlatformFee, "Owner's account balance should match the platform fee amount");
+
+        // Check the relay balances
+        (uint requiredBalance, uint currentBalance, bool isInitialized ) = relay.getRelayBalances(alice, 0);
+        assertEq(requiredBalance, requiredAmount, "Required balance should remain unchanged after withdrawal");
+        assertEq(currentBalance, 0, "Current balance should be zero after withdrawal");
+        assertTrue(isInitialized, "Relay balances should be initialized after withdrawal");
     }
 
     function testWithdrawFundsRevertsIfRelayNotLocked() public {


### PR DESCRIPTION
Uses Solidity `error`s instead of using error strings to save on gas

All unit tests for Discretionary Relay